### PR TITLE
Avoid wrapping a RuntimeException from wrapped main in an UndeclaredThrowableException

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 dirs = bundle diffcmd experiments jar javahms modulec module-info no.ion.jhms \
  no.ion.jhms.bundle
 
-.PHONY: all clean doit $(dirs)
+.PHONY: all install clean doit $(dirs)
 
 all: target =
 all: doit
+
+install: target = install
+install: modulec javahms
+
+install-old: all
+	mkdir -p ~/bin
+	rm -f ~/bin/modulec
+	ln -s $$PWD/modulec/modulec ~/bin/modulec
 
 clean: target = clean
 clean: doit

--- a/diffcmd/Makefile
+++ b/diffcmd/Makefile
@@ -3,5 +3,7 @@ target =
 all:
 	$(MAKE) -C tests $(target)
 
+install:
+
 clean: target = clean
 clean: all

--- a/javahms/Makefile
+++ b/javahms/Makefile
@@ -1,9 +1,15 @@
 
 subdirs = tests
-.PHONY: $(subdirs)
+.PHONY: all install clean $(subdirs)
 
 target =
 all: $(subdirs)
+
+install: ~/bin/javahms
+
+~/bin/javahms: javahms
+	rm -f $@
+	ln -s $$PWD/$< $@
 
 $(subdirs):
 	$(MAKE) -C $@ $(target)

--- a/javahms/javahms
+++ b/javahms/javahms
@@ -125,16 +125,20 @@ function Main {
         esac
     done
 
-    local javahms_dir=$(dirname "$0")
-    local jar_dir="$javahms_dir"/../no.ion.jhms/target
+    local jhms_home=$(readlink -m "$0"/../../no.ion.jhms)
+    if ! test -d "$jhms_home"
+    then
+        Fail "Failed to find no.ion.jhms directory: $jhms_home does not exist"
+    fi
 
+    local jar_dir="$jhms_home"/target
     if ! test -d "$jar_dir"
     then
-	Fail "Failed to find jar directory for no.ion.jhms from '$0'"
+	Fail "no.ion.jhms has not been built: $jar_dir does not exist"
     fi
 
     local version=3.0.0
-    local jar_path="$jar_dir"/no.ion.jhms-$version.jar
+    local jar_path="$jar_dir"/no.ion.jhms-"$version".jar
     if ! test -f "$jar_path"
     then
 	Fail "There is no no.ion.jhms JAR file: '$jar_path'"

--- a/modulec/Makefile
+++ b/modulec/Makefile
@@ -1,9 +1,15 @@
 subdirs = tests
 target =
 
-.PHONY: $(subdirs)
+.PHONY: all install clean $(subdirs)
 
 all: $(subdirs)
+
+install: ~/bin/modulec
+
+~/bin/modulec: modulec
+	rm -f $@
+	ln -s $$PWD/$< $@
 
 $(subdirs):
 	$(MAKE) -C $@ $(target)

--- a/modulec/modulec
+++ b/modulec/modulec
@@ -204,6 +204,12 @@ function Main {
         fi
     fi
 
+    if ! test -d "$jarpath" && [[ "$jarpath" =~ ^(.*[^/])/+$ ]]
+    then
+        mkdir -p "$jarpath"
+        jarpath="${BASH_REMATCH[1]}"
+    fi
+
     if test -d "$jarpath"
     then
         if test "$name" == ""

--- a/no.ion.jhms/Makefile
+++ b/no.ion.jhms/Makefile
@@ -1,5 +1,7 @@
 all:
 	mvn -nsu install
 
+install:
+
 clean:
 	mvn -nsu clean

--- a/no.ion.jhms/src/main/java/no/ion/jhms/RootHybridModule.java
+++ b/no.ion.jhms/src/main/java/no/ion/jhms/RootHybridModule.java
@@ -89,6 +89,10 @@ public class RootHybridModule {
             error.initCause(e);
             throw error;
         } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+
             throw new UndeclaredThrowableException(e.getCause());
         }
     }


### PR DESCRIPTION
Also: Add an install target on the top-most Makefile, that installs modulec
and javahms as symlinks.  Symlink resolution is fixed to allow javahms
to find back to the hybridmodule home directory and find the no.ion.jhms
JHMS implementation.

modulec's -f now supports ending the jar path with a /, which means it will
create that directory if it does not exist.